### PR TITLE
Standardize license headers in TOML/YAML files

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,5 @@
-# Ultralytics 🚀 - AGPL-3.0 License https://ultralytics.com/license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Ultralytics Actions https://github.com/ultralytics/actions
 # This workflow automatically formats code and documentation in PRs to official Ultralytics standards
 

--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # These are supported funding model platforms
 
 github: glenn-jocher

--- a/ISSUE_TEMPLATE/bug-report.yml
+++ b/ISSUE_TEMPLATE/bug-report.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: 🐛 Bug Report
 # title: " "
 description: Problems with YOLOv5

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 blank_issues_enabled: true
 contact_links:
   - name: 💬 Forum

--- a/ISSUE_TEMPLATE/feature-request.yml
+++ b/ISSUE_TEMPLATE/feature-request.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: 🚀 Feature Request
 description: Suggest a YOLOv5 idea
 # title: " "

--- a/ISSUE_TEMPLATE/question.yml
+++ b/ISSUE_TEMPLATE/question.yml
@@ -1,3 +1,5 @@
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 name: ❓ Question
 description: Ask a YOLOv5 question
 # title: " "

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,4 +1,5 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
+
 # Dependabot for package version updates
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 

--- a/workflows/stale.yml
+++ b/workflows/stale.yml
@@ -1,4 +1,4 @@
-# Ultralytics YOLO 🚀, AGPL-3.0 license
+# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 name: Close stale issues
 on:


### PR DESCRIPTION
This PR updates all YAML file headers to use a standardized license format. 🔄

### Changes:

- 📝 Standardized header: `# Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license`
- 🧹 Ensures consistent spacing after headers
- 🔍 Applies to all YAML files except those in `venv`

Learn more about [Ultralytics licensing](https://ultralytics.com/license) 📚

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://github.com/ultralytics/actions)<sub>

### 🌟 Summary 
License headers were updated across multiple GitHub files to include a consistent and standardized format with a link to the Ultralytics license.

### 📊 Key Changes
- Updated license headers in various files such as workflows, issue templates, and `FUNDING.yml` to a uniform format: "Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license".
- Files updated include `format.yml`, `bug-report.yml`, `config.yml`, `dependabot.yml`, and others.
  
### 🎯 Purpose & Impact
- 🔗 **Consistency**: Ensures all files reference the same standardized license message and link, improving clarity and professionalism.
- 📜 **Transparency**: Provides a direct link to Ultralytics' licensing details, making it easier for users to access.
- 🚀 **No breaking changes**: Purely a documentation improvement, with no impact on functionality or workflows.