### PR TITLE
Point banner link to YOLO Vision 2026 registration

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://www.ultralytics.com/">
+  <a href="https://www.ultralytics.com/events/yolovision?utm_source=github&utm_medium=social&utm_campaign=yolovision26&utm_content=banner">
   <img width="1024" src="https://raw.githubusercontent.com/ultralytics/assets/main/yolov8/banner-yolov8.png" alt="Ultralytics Banner"></a>
 </p>
 <div align="center">


### PR DESCRIPTION
The YOLO Vision 2026 "Register now" banner (image swapped in ultralytics/assets#184) is embedded here, but the click still went to the Platform or a generic link. This repoints only the banner's link to the YOLO Vision 2026 event page so the clickable banner matches its call to action.

Only the link wrapping the banner image is changed; all other links are untouched. Banner image is unchanged (swapped in-place via the assets repo).

Deleted: nothing — a one-line link correction; the previous URL is replaced, nothing to relocate or remove.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updates the Ultralytics GitHub profile banner link to direct visitors to YOLO Vision 2026 registration.

### 📊 Key Changes
- Replaces the banner destination URL with the YOLO Vision 2026 registration page.
- Adds campaign tracking parameters for attribution across GitHub social traffic.
- Leaves the existing banner image and surrounding profile content unchanged.

### 🎯 Purpose & Impact
- 🎟️ Makes YOLO Vision 2026 registration more accessible to GitHub visitors.
- 📈 Enables campaign performance tracking through UTM parameters.
- ✅ Provides a focused, low-risk update with no impact on code or functionality.