### PR TITLE
Add License section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ A huge thank you 🙏 to all our contributors for helping us push the boundaries
 
 [![Ultralytics open-source contributors](https://raw.githubusercontent.com/ultralytics/assets/main/im/image-contributors.png)](https://github.com/ultralytics/ultralytics/graphs/contributors)
 
+## 📄 License
+
+Ultralytics offers two licensing options to accommodate diverse needs:
+
+- **AGPL-3.0 License**: Ideal for students, researchers, and enthusiasts passionate about open collaboration and knowledge sharing. This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license promotes transparency and community involvement. See the [LICENSE](LICENSE) file for details.
+- **Enterprise License**: Designed for commercial applications, this license permits the seamless integration of Ultralytics software and AI models into commercial products and services, bypassing the copyleft requirements of AGPL-3.0. For commercial use cases, please inquire about an [Ultralytics Enterprise License](https://www.ultralytics.com/license).
+
 ## 📬 Contact
 
 For reporting bugs or suggesting new features, please use the [GitHub Issues](https://github.com/ultralytics/.github/issues) section of the relevant repository. For discussions, questions, or sharing your projects and experiences, join our active [Discord community](https://discord.com/invite/ultralytics). You can also explore various [AI solutions](https://www.ultralytics.com/solutions) developed using Ultralytics tools on our website.

--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ A huge thank you 🙏 to all our contributors for helping us push the boundaries
 
 ## 📄 License
 
-Ultralytics offers two licensing options to accommodate diverse needs:
+The contents of this repository are released under the [OSI-approved](https://opensource.org/license/agpl-3.0) AGPL-3.0 license. See the [LICENSE](LICENSE) file for details.
 
-- **AGPL-3.0 License**: Ideal for students, researchers, and enthusiasts passionate about open collaboration and knowledge sharing. This [OSI-approved](https://opensource.org/license/agpl-3.0) open-source license promotes transparency and community involvement. See the [LICENSE](LICENSE) file for details.
-- **Enterprise License**: Designed for commercial applications, this license permits the seamless integration of Ultralytics software and AI models into commercial products and services, bypassing the copyleft requirements of AGPL-3.0. For commercial use cases, please inquire about an [Ultralytics Enterprise License](https://www.ultralytics.com/license).
+Ultralytics software and AI models are separately available under a commercial [Ultralytics Enterprise License](https://www.ultralytics.com/license) for use in commercial products and services.
 
 ## 📬 Contact
 


### PR DESCRIPTION
This repo ships an AGPL-3.0 `LICENSE` file, but the README never mentioned or linked it. Added the canonical two-option `## 📄 License` section between Feedback and Contributions and Contact, matching the section order used across Ultralytics repos.

Note: `LICENSE` and `README.md` are this repo's own files and are not inherited as org-wide defaults, so this changes nothing for other repositories.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

📄 Adds clear licensing information to the `.github` repository README.

### 📊 Key Changes

- Added a dedicated **License** section to `README.md`.
- Identified the repository’s license as the **OSI-approved AGPL-3.0** license.
- Linked to the repository’s [LICENSE file](https://github.com/ultralytics/.github/blob/main/LICENSE) and the [AGPL-3.0 license details](https://opensource.org/license/agpl-3.0).
- Clarified that Ultralytics software and AI models are also available under a separate [Ultralytics Enterprise License](https://www.ultralytics.com/license).

### 🎯 Purpose & Impact

- ✅ Makes the repository’s licensing terms easier to find and understand.
- ⚖️ Helps users distinguish between the open-source AGPL-3.0 license and commercial licensing options.
- 🤝 Improves transparency for developers and organizations evaluating Ultralytics projects for personal, open-source, or commercial use.