### PR TITLE
Disable Python formatting and enable link checks in Ultralytics Actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,10 +26,10 @@ jobs:
         with:
           token: ${{ secrets._GITHUB_TOKEN || secrets.GITHUB_TOKEN }} # Auto-generated token
           labels: true # Auto-label issues/PRs using AI
-          python: true # Format Python with Ruff and docformatter
+          python: false # No Python files in this repository
           prettier: true # Format YAML, JSON, Markdown, CSS
           spelling: true # Check spelling with codespell
-          links: false # Check broken links with Lychee
+          links: true # Check broken links with Lychee
           summary: true # Generate AI-powered PR summaries
           openai_api_key: ${{ secrets.OPENAI_API_KEY }} # Powers PR summaries, labels and comments
           brave_api_key: ${{ secrets.BRAVE_API_KEY }} # Used for broken link resolution


### PR DESCRIPTION
Aligns `.github/workflows/format.yml` with the current org standard used in ultralytics/sdk, skills, openapi and lite:

- `python: false` — this repository has no Python files, so the Ruff/docformatter step was a no-op.
- `links: true` — run the Lychee broken-link check on PRs, matching the other repositories. This repo's Markdown (README, SECURITY, CODE_OF_CONDUCT, org profile) is exactly the content that benefits from it.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
Updated the repository’s formatting workflow to skip Python formatting and enable broken-link checks for its documentation.

### 📊 Key Changes
- Set `python: false` in `.github/workflows/format.yml`, disabling Ruff and docformatter checks because the repository contains no Python files.
- Set `links: true`, enabling Lychee broken-link checks for pull requests.
- Kept the existing label, Prettier, spelling, summary, and API key workflow settings unchanged.

### 🎯 Purpose & Impact
- Pull requests will no longer run the no-op Python formatting step.
- Markdown and other repository links will be checked for broken destinations.
- No other workflow behavior was changed.